### PR TITLE
Add support for authn/authz/alternate resolution preflight function

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -58,9 +58,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.903.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.903.0.tgz",
-      "integrity": "sha512-BP/giYLP8QJ63Jta59kph1F76oPITxRt/wNr3BdoEs9BtshWlGKk149UaseDB4wJtI+0TER5jtzBIUBcP6E+wA==",
+      "version": "2.980.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.980.0.tgz",
+      "integrity": "sha512-jPtCZngNOW4+rE9mPQd4fp2bU1c2mkRRrZcpa6jaSDo/WtjnfR7wtIrjKZYfyR2s0LNFqZRJadblYlroT3o8ww==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -153,12 +153,12 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
       "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
       }
     },
     "color-convert": {
@@ -175,9 +175,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -388,9 +388,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iiif-processor": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-0.3.5.tgz",
-      "integrity": "sha512-Q6caRb0R8lwDaIzCboS2RLjo5HOCCMVJxQx9a2JFfUnYnpjB8dvlAAhJqNh0Dy2PsNWolQ+ogtZU84w7oY5o+w==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-0.3.6.tgz",
+      "integrity": "sha512-ZIyjatog2iNk9jXoSg/mW7/IQ+tsvgFRyV+QeDAOdVanfM8jV4l2BjKcNsU/tOdr15P7ODycpZSybbQDf5HGtQ==",
       "requires": {
         "mime-types": "^2.1.21",
         "probe-image-size": "^4.0.0",
@@ -480,16 +480,16 @@
       }
     },
     "mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
     },
     "mime-types": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
       "requires": {
-        "mime-db": "1.47.0"
+        "mime-db": "1.49.0"
       }
     },
     "mimic-response": {
@@ -545,9 +545,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node-abi": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
-      "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
       "requires": {
         "semver": "^5.4.1"
       },
@@ -560,9 +560,9 @@
       }
     },
     "node-addon-api": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -898,9 +898,9 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Lambda wrapper for iiif-processor",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "uri-js": "^4.4.1"
+  },
   "devDependencies": {
     "aws-sdk": "^2.368.0",
     "coveralls": "^3.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ const helpers = require('./helpers');
 const resolvers = require('./resolvers');
 const errorHandler = require('./error');
 
+const preflight = process.env.preflight === 'true';
+
 const handleRequestFunc = async (event, context, callback) => {
   const { eventPath, fileMissing, getRegion } = helpers;
 
@@ -32,7 +34,7 @@ const handleRequestFunc = async (event, context, callback) => {
 
 const handleImageRequestFunc = async (event, context, callback) => {
   const { getUri, isTooLarge } = helpers;
-  const { streamResolver, dimensionResolver } = resolvers;
+  const { streamResolver, dimensionResolver } = resolvers.resolverFactory(event, preflight);
   const { getCached, makeCache } = cache;
 
   let resource;

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,9 @@
   "description": "Lambda wrapper for iiif-processor",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "uri-js": "^4.4.1"
+  },
   "devDependencies": {
     "aws-sdk": "^2.368.0",
     "iiif-processor": "~0.3.4"

--- a/template.yml
+++ b/template.yml
@@ -49,6 +49,10 @@ Parameters:
     Type: Number
     Description: The timeout for the lambda.
     Default: 10
+  PreflightFunctionARN:
+    Type: String
+    Description: ARN of the CloudFront Function to use for auth/preflight
+    Default: ""
 Conditions:
   CreateCacheBucket: 
     Fn::Equals: [!Ref UseCacheBucket, "true"]
@@ -56,10 +60,15 @@ Conditions:
     Fn::Or:
       - Fn::Equals: [!Ref UseCloudFront, "true"]
       - Fn::Equals: [!Ref UseCacheBucket, "true"]
+      - Fn::Not:
+          - Fn::Equals: [!Ref PreflightFunctionARN, ""]
   CreateCacheBucketAndDistribution:
     Fn::And:
       - Condition: CreateCacheBucket
       - Condition: CreateDistribution
+  UsePreflightFunction:
+    Fn::Not:
+      - Fn::Equals: [!Ref PreflightFunctionARN, ""]
 Resources:
   Dependencies:
     Type: "AWS::Serverless::LayerVersion"
@@ -69,10 +78,10 @@ Resources:
       Description: Dependencies for IIIF app
       ContentUri: ./dependencies
       CompatibleRuntimes:
-        - nodejs12.x
+        - nodejs14.x
       LicenseInfo: "Apache-2.0"
     Metadata:
-      BuildMethod: nodejs12.x
+      BuildMethod: nodejs14.x
   CacheBucket:
     Type: "AWS::S3::Bucket"
     Condition: CreateCacheBucket
@@ -102,7 +111,7 @@ Resources:
   IiifFunction:
     Type: "AWS::Serverless::Function"
     Properties:
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Handler: index.handler
       MemorySize: 3008
       Timeout:
@@ -144,7 +153,12 @@ Resources:
             Fn::If: 
               - CreateCacheBucket
               - Fn::Sub: "${AWS::StackName}-cache"
-              - AWS::NoValue
+              - !Ref AWS::NoValue
+          preflight:
+            Fn::If:
+              - UsePreflightFunction
+              - true
+              - !Ref AWS::NoValue
           tiffBucket:
             Fn::Sub: "${SourceBucket}"
       Events:
@@ -509,7 +523,7 @@ Resources:
                         - !Ref CachingIdentity
                 DomainName:
                   Fn::Sub: "${CacheBucket}.s3.${AWS::Region}.amazonaws.com"
-              - AWS::NoValue
+              - !Ref AWS::NoValue
         OriginGroups:
           Quantity: 
             Fn::If: [CreateCacheBucket, 1, 0]
@@ -536,6 +550,12 @@ Resources:
           MinTTL: !Ref CacheMinimumTTL
           MaxTTL: !Ref CacheMaximumTTL
           DefaultTTL: !Ref CacheDefaultTTL
+          FunctionAssociations:
+            Fn::If:
+              - UsePreflightFunction
+              - - EventType: viewer-request
+                  FunctionARN: !Ref PreflightFunctionARN
+              - !Ref AWS::NoValue
 Outputs:
   Endpoint:
     Description: IIIF Endpoint URL

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -1,9 +1,11 @@
 /* eslint-env jest */
 const AWS = require('aws-sdk');
-const { streamResolver, dimensionResolver } = require('../src/resolvers');
+const resolvers = require('../src/resolvers');
 const AWSMockS3 = require('./__mocks/mockS3');
 
-describe('resolvers', () => {
+describe('default resolvers', () => { // eslint-disable-line max-lines-per-function
+  const { streamResolver, dimensionResolver } = resolvers.resolverFactory({ headers: {} }, false);
+
   beforeEach(() => {
     AWS.S3 = AWSMockS3.S3;
   });
@@ -21,17 +23,55 @@ describe('resolvers', () => {
 
   describe('dimensionResolver', () => {
     it('has metadata dimensions', async () => {
-      const expected = {
-        width: 100,
-        height: 200
-      };
+      const expected = { width: 100, height: 200 };
       const result = await dimensionResolver('dimensions');
       expect(result).toEqual(expected);
     });
 
     it('does not have metadata dimensions', async () => {
       const expected = null;
-      const result = await dimensionResolver('no-dimenstions');
+      const result = await dimensionResolver('no-dimensions');
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('preflight resolvers', () => { // eslint-disable-line max-lines-per-function
+  beforeEach(() => {
+    AWS.S3 = AWSMockS3.S3;
+  });
+
+  describe('streamResolver', () => {
+    const { streamResolver } = resolvers.resolverFactory({ headers: { 'x-preflight-location': 's3://test-bucket/dimensions.tif' } }, true);
+    it('returns a stream and cleans up', async () => {
+      const callback = jest.fn(() => {});
+      await streamResolver('id', callback);
+      expect(callback).toHaveBeenCalled();
+      expect(AWSMockS3.end).toHaveBeenCalled();
+      expect(AWSMockS3.destroy).toHaveBeenCalled();
+      expect(AWSMockS3.abort).toHaveBeenCalled();
+    });
+  });
+
+  describe('dimensionResolver', () => {
+    it('preflight dimensions', async () => {
+      const { dimensionResolver } = resolvers.resolverFactory({ headers: { 'x-preflight-dimensions': '{ "width": 640, "height": 480 }' } }, true);
+      const expected = { width: 640, height: 480 };
+      const result = await dimensionResolver('dimensions');
+      expect(result).toEqual(expected);
+    });
+
+    it('no preflight dimensions / metadata dimensions', async () => {
+      const { dimensionResolver } = resolvers.resolverFactory({ headers: { 'x-preflight-location': 's3://test-bucket/dimensions.tif' } }, true);
+      const expected = { width: 100, height: 200 };
+      const result = await dimensionResolver('dimensions');
+      expect(result).toEqual(expected);
+    });
+
+    it('no preflight dimensions / no metadata dimensions', async () => {
+      const { dimensionResolver } = resolvers.resolverFactory({ headers: { 'x-preflight-location': 's3://test-bucket/no-dimensions.tif' } }, true);
+      const expected = null;
+      const result = await dimensionResolver('no-dimensions');
       expect(result).toEqual(expected);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4779,6 +4779,13 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uri-js@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"


### PR DESCRIPTION
This PR adds support for an optional preflight function – a CloudFront function that can:

* Perform authentication / authorization before the lambda is called
* Update the request to specify the image location / dimensions (as an alternative to forking the code and overriding the resolvers)

Includes tests and documentation.

resolves #36 