### PR TITLE
resolver template is not used even if specified

### DIFF
--- a/sam/standalone/template.yml
+++ b/sam/standalone/template.yml
@@ -154,22 +154,23 @@ Resources:
                   Fn::Sub: "arn:aws:s3:::${SourceBucket}"
       Environment:
         Variables:
-          cacheBucket: 
+          cacheBucket:
             Fn::If:
               - UseCacheBucket
               - !Ref CacheBucket
               - !Ref AWS::NoValue
-          density: 
+          density:
             Fn::If:
               - UsePixelDensity
               - !Ref PixelDensity
               - !Ref AWS::NoValue
-          forceHost: 
+          forceHost:
             Fn::If:
               - UseForceHost
               - !Ref ForceHost
               - !Ref AWS::NoValue
           preflight: !Ref Preflight
+          resolverTemplate: !Ref ResolverTemplate
           tiffBucket: !Ref SourceBucket
 Outputs:
   Endpoint:


### PR DESCRIPTION
When we specified ResolverTemplate in our CloufFormation calls (eg sam deploy), it was not actually being set. Manually setting the env var in the lambda console worked fine. This connects the last dot so that setting the parameter makes it all the way to the lambda configuration.